### PR TITLE
fix: country code logic

### DIFF
--- a/website/src/app/contacts/shared/phone-number/phone-number.pipe.ts
+++ b/website/src/app/contacts/shared/phone-number/phone-number.pipe.ts
@@ -82,7 +82,7 @@ import { phoneNumberErrorMessages } from './phone-number-error-messages';
 })
 export class PhoneNumberPipe implements PipeTransform {
 
-  transform(value: string = '', format?: string, countryCode: string = 'us', allowEmptyString?: boolean): string {
+  transform(value: string = '', format?: string, countryCode: string = '', allowEmptyString?: boolean): string {
     let phoneNumber: PhoneNumber = null;
     let formattedPhoneNumber = '';
 


### PR DESCRIPTION
The 'us' country code was being applied by default. There should be no default country code, so this is fixed now.