### PR TITLE
docs: remove gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Gitter chat](https://badges.gitter.im/testing-angular-applications/gitter.svg)](https://gitter.im/testing-angular-applications/lobby)
 [![Dependencies Status](https://david-dm.org/testing-angular-applications/testing-angular-applications/website/status.svg)](https://david-dm.org/testing-angular-applications/testing-angular-applications/website)
 [![devDependencies Status](https://david-dm.org/testing-angular-applications/testing-angular-applications/website/dev-status.svg)](https://david-dm.org/testing-angular-applications/testing-angular-applications/website?type=dev)
 [![CircleCI Status](https://circleci.com/gh/testing-angular-applications/testing-angular-applications.svg?style=shield)](https://circleci.com/gh/testing-angular-applications/testing-angular-applications)


### PR DESCRIPTION
We should direct people to the forum https://forums.manning.com/forums/testing-angular-applications since the Gitter channel isn't being used. Making one system of record for issues, at least for the time being, should simplify things.