### PR TITLE
Use the CircleCI node 8 w/ browsers image to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/workspace
     docker:
-      - image: circleci/node:7-browsers
+      - image: circleci/node:8-browsers
     steps:
       - checkout
       

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Dependencies Status](https://david-dm.org/testing-angular-applications/testing-angular-applications/website/status.svg)](https://david-dm.org/testing-angular-applications/testing-angular-applications/website)
-[![devDependencies Status](https://david-dm.org/testing-angular-applications/testing-angular-applications/website/dev-status.svg)](https://david-dm.org/testing-angular-applications/testing-angular-applications/website?type=dev)
 [![CircleCI Status](https://circleci.com/gh/testing-angular-applications/testing-angular-applications.svg?style=shield)](https://circleci.com/gh/testing-angular-applications/testing-angular-applications)
 
 # Testing Angular Applications

--- a/chapter09/package.json
+++ b/chapter09/package.json
@@ -2,7 +2,7 @@
   "name": "chapter-9-code",
   "version": "1.0.0",
   "engines": {
-    "node": "7.x"
+    "node": "8.x"
   },
   "license": "MIT",
   "angular-cli": {},


### PR DESCRIPTION
- Node 8 is the new LTS, so we should migrate our CircleCI to node 8